### PR TITLE
Fix for Combining Data Based on ATA 

### DIFF
--- a/filter_configs/var_of_interest.json
+++ b/filter_configs/var_of_interest.json
@@ -4,7 +4,7 @@
   "output_file_name": "filtered.parquet",
   "data_files": [
     {
-      "fileName": "ISDP LOGBOOK REPORT.csv",
+      "fileName": "TABLES_ADD_20240515/ISDP LOGBOOK REPORT.csv",
       "fileType": "csv",
       "colOfInterest": ["FLEET","FAULT_FOUND_DATE","FAULT_SOURCE","FAULT_NAME","FAULT_SDESC","CORRECTIVE_ACTION","MAINT_DELAY_TIME_QT","ATA","FAULT_SEVERITY"],
       "separator": ","

--- a/run.sh
+++ b/run.sh
@@ -1,22 +1,12 @@
-#!/bin/bash
-
+#!/bin/bash 
+#
 SRC_DIR="src"
 ENTRY_FILE="main.py"
 
-# Default arguments
-DEFAULT_ARGS=(
-    --config "filter_configs/var_of_interest.json"
-    --test_mode
-    --test_rows 33000
-    --drop_duplicates
-    --split "merged"
-)
-
-# Check if arguments are provided
-if [ $# -eq 0 ]; then
-    ARGS=("${DEFAULT_ARGS[@]}")
-else
-    ARGS=("$@")
-fi
-
-python $SRC_DIR/$ENTRY_FILE "${ARGS[@]}"
+python $SRC_DIR/$ENTRY_FILE \
+    --config "filter_configs/var_of_interest.json" \
+    --test_mode \
+    --test_rows 33000 \
+    --drop_duplicates \
+    --split "merged" \
+    "$@"

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,10 @@
 SRC_DIR="src"
 ENTRY_FILE="main.py"
 
-python $SRC_DIR/$ENTRY_FILE
+python $SRC_DIR/$ENTRY_FILE \
+    --config "filter_configs/var_of_interest.json" \
+    --test_mode \
+    --test_rows 33000 \
+    --drop_duplicates \
+    --split "merged" \
+    "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,12 +1,22 @@
-#!/bin/bash 
-#
+#!/bin/bash
+
 SRC_DIR="src"
 ENTRY_FILE="main.py"
 
-python $SRC_DIR/$ENTRY_FILE \
-    --config "filter_configs/var_of_interest.json" \
-    --test_mode \
-    --test_rows 33000 \
-    --drop_duplicates \
-    --split "merged" \
-    "$@"
+# Default arguments
+DEFAULT_ARGS=(
+    --config "filter_configs/var_of_interest.json"
+    --test_mode
+    --test_rows 33000
+    --drop_duplicates
+    --split "merged"
+)
+
+# Check if arguments are provided
+if [ $# -eq 0 ]; then
+    ARGS=("${DEFAULT_ARGS[@]}")
+else
+    ARGS=("$@")
+fi
+
+python $SRC_DIR/$ENTRY_FILE "${ARGS[@]}"

--- a/src/main.py
+++ b/src/main.py
@@ -42,15 +42,16 @@ def split_dataframe_to_csv(
             subset_df.to_csv(filename, index=False)
             print(f"File created: {filename}")
 
-    # Extract the first two letters from each ATA and store them in a set to get unique ATA
-    unique_ATAs = set([x[:2] for x in unique_values])
+    if split_type == "merged":
+        # Extract the first two letters from each ATA and store them in a set to get unique ATA
+        unique_ATAs = set([x[:2] for x in unique_values])
 
-    # Loop through each unique prefix
-    for value in unique_ATAs:
-        subset_df = df[df[column_name].str.startswith(value)]
-        filename = f"ata_filtered/ATA_{value[:2]}.csv"
-        subset_df.to_csv(filename, index=False)
-        print(f"File created: {filename}")
+        # Loop through each unique prefix
+        for value in unique_ATAs:
+            subset_df = df[df[column_name].str.startswith(value)]
+            filename = f"ata_filtered/ATA_{value[:2]}_merged.csv"
+            subset_df.to_csv(filename, index=False)
+            print(f"File created: {filename}")
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -35,12 +35,19 @@ def split_dataframe_to_csv(df, column_name):
     df (pd.DataFrame): The input DataFrame.
     column_name (str): The name of the column to split the DataFrame by.
     """
+
+    # Get the unique values from the specified column
     unique_values = df[column_name].unique()
 
+    # Extract the first two letters from each ATA and store them in a set to get unique ATA
+    unique_ATAs = set([x[:2] for x in unique_values])
+
+    # Create the directory "ata_filtered" if it does not exist
     if not os.path.exists("ata_filtered"):
         os.makedirs("ata_filtered")
 
-    for value in unique_values:
+    # Loop through each unique prefix
+    for value in unique_ATAs:
         subset_df = df[df[column_name].str.startswith(value)]
         filename = f"ata_filtered/ATA_{value[:2]}.csv"
         subset_df.to_csv(filename, index=False)

--- a/src/main.py
+++ b/src/main.py
@@ -1,33 +1,18 @@
+import argparse
 import json
 import os
+from ast import parse
 from enum import unique
+from typing import Literal
 
 import pandas as pd
 
 from copa_modules import _types, data_processor
 
-BASE_PATH = "TABLES_ADD_20240515/"
 
-config: _types.data_config | None = None
-# Path of the config file relative to the run.sh file.
-with open("filter_configs/var_of_interest.json") as f:
-    config = json.load(f)
-# Create a DataProcessor object with the configuration and base path
-my_data_processor = data_processor(
-    config,
-    base_path=BASE_PATH,  # Path of the Directory where the dataset is located relative to run.sh.
-    test_mode=True,  # Test mode which will only load a subset of the data
-    test_rows=33000,  # Number of rows to load in test mode
-    drop_duplicates=False,  # Drop duplicates from the dataset (Currently set true for Copa dataset)
-    no_cache=False,  # Do not use cached data, i.e., data from the copa_output folder.
-)
-
-# Below Load function is returning the filtered dataframe.
-my_filtered_data = my_data_processor.load()
-print(f"Shape of filtered data: {my_filtered_data.shape}")
-
-
-def split_dataframe_to_csv(df, column_name):
+def split_dataframe_to_csv(
+    df, column_name, split_type: Literal["full", "merged"] = "full"
+):
     """
     Splits a pandas DataFrame into separate CSV files based on unique values in the specified column.
 
@@ -35,23 +20,92 @@ def split_dataframe_to_csv(df, column_name):
     df (pd.DataFrame): The input DataFrame.
     column_name (str): The name of the column to split the DataFrame by.
     """
-
-    # Get the unique values from the specified column
-    unique_values = df[column_name].unique()
-
-    # Extract the first two letters from each ATA and store them in a set to get unique ATA
-    unique_ATAs = set([x[:2] for x in unique_values])
-
     # Create the directory "ata_filtered" if it does not exist
     if not os.path.exists("ata_filtered"):
         os.makedirs("ata_filtered")
 
-    # Loop through each unique prefix
-    for value in unique_ATAs:
-        subset_df = df[df[column_name].str.startswith(value)]
-        filename = f"ata_filtered/ATA_{value[:2]}.csv"
-        subset_df.to_csv(filename, index=False)
-        print(f"File created: {filename}")
+    if split_type == "merged":
+        # Get the unique values from the specified column
+        unique_values = df[column_name].unique()
+
+        # Extract the first two letters from each ATA and store them in a set to get unique ATA
+        unique_ATAs = set([x[:2] for x in unique_values])
+
+        # Loop through each unique prefix
+        for value in unique_ATAs:
+            subset_df = df[df[column_name].str.startswith(value)]
+            filename = f"ata_filtered/ATA_{value[:2]}.csv"
+            subset_df.to_csv(filename, index=False)
+            print(f"File created: {filename}")
+
+    elif split_type == "full":
+        unique_values = df[column_name].unique()
+
+        for value in unique_values:
+            subset_df = df[df[column_name] == value]
+            filename = f"ata_filtered/ATA_{value}.csv"
+            subset_df.to_csv(filename, index=False)
+            print(f"File created: {filename}")
 
 
-split_dataframe_to_csv(my_filtered_data, "ATA")
+def main():
+
+    parser = argparse.ArgumentParser(description="Copa Module")
+
+    parser.add_argument(
+        "--split",
+        choices=["full", "merged"],
+        required=False,
+        default="full",
+        help="Specify how the data is separate in CSV files.\n'full' creates separate CSV for every possible ATA\n'merged' merges the sub classes of ATA and creates separate CSV files.",
+    )
+
+    parser.add_argument("--config", required=True, help="Path to config file.")
+
+    parser.add_argument(
+        "--test_mode",
+        action="store_true",
+        help="Enable test mode which will only load a subset of the data",
+    )
+
+    parser.add_argument(
+        "--test_rows",
+        type=int,
+        default=1000,
+        help="Number of rows to load in test mode",
+    )
+
+    parser.add_argument(
+        "--drop_duplicates",
+        action="store_true",
+        help="Drop duplicates from the dataset",
+    )
+
+    parser.add_argument(
+        "--no_cache", action="store_true", help="Disable caching if applicable"
+    )
+
+    args = parser.parse_args()
+
+    config: _types.data_config | None = None
+
+    # Path of the config file relative to the run.sh file.
+    with open(args.config) as f:
+        config = json.load(f)
+    # Create a DataProcessor object with the configuration and base path
+    my_data_processor = data_processor(
+        config,
+        test_mode=args.test_mode,  # Test mode which will only load a subset of the data
+        test_rows=args.test_rows,  # Number of rows to load in test mode
+        drop_duplicates=args.drop_duplicates,  # Drop duplicates from the dataset (Currently set true for Copa dataset)
+        no_cache=args.no_cache,  # Do not use cached data, i.e., data from the copa_output folder.
+    )
+
+    # Below Load function is returning the filtered dataframe.
+    my_filtered_data = my_data_processor.load()
+    print(f"Shape of filtered data: {my_filtered_data.shape}")
+    split_dataframe_to_csv(my_filtered_data, "ATA", args.split)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,7 @@
 import argparse
 import json
 import os
-from ast import parse
-from enum import unique
 from typing import Literal
-
-import pandas as pd
 
 from copa_modules import _types, data_processor
 
@@ -14,38 +10,47 @@ def split_dataframe_to_csv(
     df, column_name, split_type: Literal["full", "merged"] = "full"
 ):
     """
-    Splits a pandas DataFrame into separate CSV files based on unique values in the specified column.
+    Split a pandas DataFrame into separate CSV files based on unique values in the specified column.
 
-    Parameters:
-    df (pd.DataFrame): The input DataFrame.
-    column_name (str): The name of the column to split the DataFrame by.
+    Args:
+        df (pd.DataFrame): The input DataFrame to be split.
+        column_name (str): The name of the column to split the DataFrame by.
+        split_type (Literal["full", "merged"], optional): The splitting strategy to be used. Defaults to "full".
+            - "full": Create one CSV file for each unique ATA in the specified column.
+            - "merged": Create one CSV file for each unique prefix (first two characters) of ATA in the specified column.
+
+    Returns:
+        None
+
+    Side Effects:
+        Creates CSV files in the "ata_filtered" directory.
+        If the directory does not exist, it will be created.
+        Each CSV file is named "ATA_<value>.csv" or "ATA_<prefix>.csv" based on the split_type.
     """
     # Create the directory "ata_filtered" if it does not exist
     if not os.path.exists("ata_filtered"):
         os.makedirs("ata_filtered")
 
-    if split_type == "merged":
-        # Get the unique values from the specified column
-        unique_values = df[column_name].unique()
+    # Get the unique values from the specified column
+    unique_values = df[column_name].unique()
 
-        # Extract the first two letters from each ATA and store them in a set to get unique ATA
-        unique_ATAs = set([x[:2] for x in unique_values])
-
-        # Loop through each unique prefix
-        for value in unique_ATAs:
-            subset_df = df[df[column_name].str.startswith(value)]
-            filename = f"ata_filtered/ATA_{value[:2]}.csv"
-            subset_df.to_csv(filename, index=False)
-            print(f"File created: {filename}")
-
-    elif split_type == "full":
-        unique_values = df[column_name].unique()
+    if split_type == "full":
 
         for value in unique_values:
             subset_df = df[df[column_name] == value]
             filename = f"ata_filtered/ATA_{value}.csv"
             subset_df.to_csv(filename, index=False)
             print(f"File created: {filename}")
+
+    # Extract the first two letters from each ATA and store them in a set to get unique ATA
+    unique_ATAs = set([x[:2] for x in unique_values])
+
+    # Loop through each unique prefix
+    for value in unique_ATAs:
+        subset_df = df[df[column_name].str.startswith(value)]
+        filename = f"ata_filtered/ATA_{value[:2]}.csv"
+        subset_df.to_csv(filename, index=False)
+        print(f"File created: {filename}")
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -41,8 +41,8 @@ def split_dataframe_to_csv(df, column_name):
         os.makedirs("ata_filtered")
 
     for value in unique_values:
-        subset_df = df[df[column_name] == value]
-        filename = f"ata_filtered/ATA_{value}.csv"
+        subset_df = df[df[column_name].str.startswith(value)]
+        filename = f"ata_filtered/ATA_{value[:2]}.csv"
         subset_df.to_csv(filename, index=False)
         print(f"File created: {filename}")
 


### PR DESCRIPTION
This pull request fixes the functionality for splitting a pandas DataFrame into separate CSV files based on the first two letters of the ATA values. Previously, the code created separate files for each unique ATA value. Now, it correctly combines data entries that share the same ATA prefix and saves them into a single CSV file

### Implementation Details
**Extract Unique Prefixes**: The script extracts the first two letters from each ATA value in the specified column.
**Filter and Save**: It filters the DataFrame by these prefixes and saves each group into a CSV file named accordingly.